### PR TITLE
Fix version detection for packages with '_' in their names (IE: model_mommy)

### DIFF
--- a/peep.py
+++ b/peep.py
@@ -172,7 +172,7 @@ def version_of_archive(filename, package_name):
         if filename.endswith(ext):
             filename = filename[:-len(ext)]
             break
-    if not filename.startswith(package_name):
+    if not filename.replace('_', '-').startswith(package_name):
         # TODO: What about safe/unsafe names?
         raise RuntimeError("The archive '%s' didn't start with the package name '%s', so I couldn't figure out the version number. My bad; improve me." %
                            (filename, package_name))


### PR DESCRIPTION
Pip replaces '_' in package names with '-' which breaks the version detection code for packages such as "model_mommy". A simple fix is to replace the '_' in the download archive name with '-' so that they will match the package name pip returns.
