### PR TITLE
Handle git sha tarballs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,9 @@ Switching to Peep
     # sha256: u_8C3DCeUoRt2WPSlIOnKV_MAhYkc40zNZxDlxCA-as
     Pygments==1.4
 
+    # sha256: A1gwhyCNozcxug18_9RjJTmJQa1rctOt-AnP7_yR0PM
+    https://github.com/jsocol/commonware/archive/b5544185b2d24adc1eb512735990752400ce9cbd.zip#egg=commonware
+
     -------------------------------
     Not proceeding to installation.
 2. Vet the packages coming off PyPI in whatever way you typically do.


### PR DESCRIPTION
This allows us to have urls like this in the requirements file:

https://github.com/jsocol/commonware/archive/b5544185b2d24adc1eb512735990752400ce9cbd.zip#egg=commonware

which is a tarball from github for a specific commit of a project.

If this is in the requirements file, the peep will download it every
time because there's no way to know what version it is plus versions
don't really have a lot of meaning for code being pulled from a
repository (many commits all have the same "version number").

This alleviates the problem with issue #19.

Feedback? Thoughts? Vitriolic utterances in iambic pentameter?
