### PR TITLE
Keep failed files

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,8 +100,12 @@ this::
 
         requests: expected FWvz7Ce6nsfgz4--AoCHGAmdIY3kA-tkpxTXO6GimrE
                        got YhddA1kUpMLVODNbhIgHfQn88vioPHLwayTyqwOJEgY
+                  keeping copy in "..."
 
 It will then exit with a status of 1. Freak out appropriately.
+
+A copy of the failing file will be copied to your current directory
+for inspection.
 
 
 Other Niceties


### PR DESCRIPTION
I don't see any options that peep takes that pip doesn't, so I didn't try to wedge one in. Perhaps this behavior should be optional, though?

Personally, I'd make this the default and have an option to turn it off if you really want.