### PR TITLE
Package checks are now case-insensitive.

### DIFF
--- a/peep.py
+++ b/peep.py
@@ -211,7 +211,7 @@ def version_of_download(filename, package_name):
         # Handle github sha tarball downloads.
         if is_git_sha(filename):
             filename = package_name + '-' + filename
-        if not filename.replace('_', '-').startswith(package_name):
+        if not filename.lower().replace('_', '-').startswith(package_name.lower()):
             # TODO: Should we replace runs of [^a-zA-Z0-9.], not just _, with -?
             give_up(filename, package_name)
         return filename[len(package_name) + 1:]  # Strip off '-' before version.


### PR DESCRIPTION
This allows packages to be case-insensitive in the requirements file when asking to install them from peep.
Ex: sqlalchemy==0.6.4 will now match to SQLAlchemy==0.6.4
