### PR TITLE
Pip 6.0+ compatibility fixes

### DIFF
--- a/peep.py
+++ b/peep.py
@@ -76,7 +76,6 @@ try:
 except ImportError:
     from pip import logger  # https://github.com/pypa/pip/pull/2008
 from pip.req import parse_requirements
-from pip.download import PipSession
 
 
 __version__ = 2, 0, 0
@@ -732,9 +731,14 @@ def downloaded_reqs_from_path(path, argv):
     :arg argv: The commandline args, starting after the subcommand
 
     """
-    return [DownloadedReq(req, argv) for req in
-            parse_requirements(path, options=EmptyOptions(),
-                               session=PipSession())]
+    try:
+        return [DownloadedReq(req, argv) for req in
+                parse_requirements(path, options=EmptyOptions())]
+    except TypeError:
+        from pip.download import PipSession
+        return [DownloadedReq(req, argv) for req in
+                parse_requirements(path, options=EmptyOptions(),
+                                   session=PipSession())]
 
 
 def peep_install(argv):

--- a/peep.py
+++ b/peep.py
@@ -76,6 +76,7 @@ try:
 except ImportError:
     from pip import logger  # https://github.com/pypa/pip/pull/2008
 from pip.req import parse_requirements
+from pip.download import PipSession
 
 
 __version__ = 2, 0, 0
@@ -234,6 +235,7 @@ class EmptyOptions(object):
     """
     default_vcs = None
     skip_requirements_regex = None
+    isolated_mode = False
 
 
 def memoize(func):
@@ -731,7 +733,8 @@ def downloaded_reqs_from_path(path, argv):
 
     """
     return [DownloadedReq(req, argv) for req in
-            parse_requirements(path, options=EmptyOptions())]
+            parse_requirements(path, options=EmptyOptions(),
+                               session=PipSession())]
 
 
 def peep_install(argv):

--- a/peep.py
+++ b/peep.py
@@ -71,7 +71,10 @@ except ImportError:
     except ImportError:
         from pip.util import url_to_filename as url_to_path  # 0.6.2
 from pip.index import PackageFinder, Link
-from pip.log import logger
+try:
+    from pip.log import logger
+except ImportError:
+    from pip import logger  # https://github.com/pypa/pip/pull/2008
 from pip.req import parse_requirements
 
 

--- a/peep.py
+++ b/peep.py
@@ -74,7 +74,7 @@ from pip.index import PackageFinder, Link
 try:
     from pip.log import logger
 except ImportError:
-    from pip import logger  # https://github.com/pypa/pip/pull/2008
+    from pip import logger  # 6.0
 from pip.req import parse_requirements
 
 
@@ -735,6 +735,10 @@ def downloaded_reqs_from_path(path, argv):
         return [DownloadedReq(req, argv) for req in
                 parse_requirements(path, options=EmptyOptions())]
     except TypeError:
+        # session is a required kwarg as of pip 6.0 and will raise
+        # a TypeError if missing. It needs to be a PipSession instance,
+        # but in older versions we can't import it from pip.download
+        # (nor do we need it at all) so we only import it in this except block
         from pip.download import PipSession
         return [DownloadedReq(req, argv) for req in
                 parse_requirements(path, options=EmptyOptions(),


### PR DESCRIPTION
Use stdlib logger in newer versions of pip
See https://github.com/pypa/pip/pull/2008 for details