### PR TITLE
Support index in requirements

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -274,7 +274,7 @@ class FullStackTests(ServerTestCase):
         On failure, raise CalledProcessError.
 
         """
-        index = "-i {}".format(index or cls.index_url())
+        index = "-i {0}".format(index or cls.index_url())
         with requirements("\n".join([index, reqs])) as reqs_path:
             return cls.install_from_path_no_index(reqs_path)
 


### PR DESCRIPTION
Pip supports specifying a custom index url inside the requirements file. For example
```
-i http://my.pypi.com/
Django==1.7
```
`peep` doesn't pass the `finder` object to the requirements parser, so the only index active is the default index. Packages available only through another index are not checked. This PR fixes `peep` to take these custom index url's into account.