### PR TITLE
Don't append #egg=foo to URLs in missing hashes output (fixes #76)

### DIFF
--- a/peep.py
+++ b/peep.py
@@ -706,8 +706,6 @@ class MissingReq(DownloadedReq):
     def error(self):
         if self._url():
             line = self._url()
-            if self._name() not in filename_from_url(self._url()):
-                line = '%s#egg=%s' % (line, self._name())
         else:
             line = '%s==%s' % (self._name(), self._version())
         return '# sha256: %s\n%s\n' % (self._actual_hash(), line)


### PR DESCRIPTION
The existing conditional was incorrect (it appended #egg=foo even if it was already present, due to filename_from_url() stripping away the fragment) and should have been replaced by a self._url().endswith() or similar. 

However peep already enforces that URLs have the package name specified ("Unable to determine package name from URL ...; add #egg=") so by the time we reach this point, self._url() will always have the package name specified & we'll never need to append it.