### PR TITLE
Fix flake8 linter warnings

### DIFF
--- a/peep.py
+++ b/peep.py
@@ -715,14 +715,14 @@ class MismatchedReq(DownloadedReq):
                 "freak out, because someone has tampered with the packages.\n\n")
 
     def error(self):
-        preamble = '    %s: expected%s' % (
-            self._project_name(),
-            ' one of' if len(self._expected_hashes()) > 1 else '')
-        return '%s %s\n%s got %s' % (
-            preamble,
-            ('\n' + ' ' * (len(preamble) + 1)).join(self._expected_hashes()),
-            ' ' * (len(preamble) - 4),
-            self._actual_hash())
+        preamble = '    %s: expected' % self._project_name()
+        if len(self._expected_hashes()) > 1:
+            preamble += ' one of'
+        padding = '\n' + ' ' * (len(preamble) + 1)
+        return '%s %s\n%s got %s' % (preamble,
+                                     padding.join(self._expected_hashes()),
+                                     ' ' * (len(preamble) - 4),
+                                     self._actual_hash())
 
     @classmethod
     def foot(cls):

--- a/peep.py
+++ b/peep.py
@@ -35,7 +35,6 @@ from itertools import chain
 from linecache import getline
 import mimetypes
 from optparse import OptionParser
-from os import listdir
 from os.path import join, basename, splitext, isdir
 from pickle import dumps, loads
 import re

--- a/peep.py
+++ b/peep.py
@@ -60,6 +60,8 @@ from pkg_resources import require, VersionConflict, DistributionNotFound
 # say `pip install peep.tar.gz` and thus pull down an untrusted copy of pip
 # from PyPI. Instead, we make sure it's installed and new enough here and spit
 # out an error message if not:
+
+
 def activate(specifier):
     """Make a compatible version of pip importable. Raise a RuntimeError if we
     couldn't."""
@@ -70,9 +72,10 @@ def activate(specifier):
         raise RuntimeError('The installed version of pip is too old; peep '
                            'requires ' + specifier)
 
-activate('pip>=0.6.2')  # Before 0.6.2, the log module wasn't there, so some
-                        # of our monkeypatching fails. It probably wouldn't be
-                        # much work to support even earlier, though.
+# Before 0.6.2, the log module wasn't there, so some
+# of our monkeypatching fails. It probably wouldn't be
+# much work to support even earlier, though.
+activate('pip>=0.6.2')
 
 import pip
 from pip.commands.install import InstallCommand
@@ -224,7 +227,8 @@ HASH_COMMENT_RE = re.compile(
                                #   just trailing whitespace if there is no
                                #   comment. Also strip trailing newlines.
     (?:\#(?P<comment>.*))?     # Comments can be anything after a whitespace+#
-    $""", re.X)                #   and are optional.
+                               #   and are optional.
+    $""", re.X)
 
 
 def peep_hash(argv):
@@ -400,7 +404,9 @@ class DownloadedReq(object):
             return version
 
         def give_up(filename, package_name):
-            raise RuntimeError("The archive '%s' didn't start with the package name '%s', so I couldn't figure out the version number. My bad; improve me." %
+            raise RuntimeError("The archive '%s' didn't start with the package name "
+                               "'%s', so I couldn't figure out the version number. "
+                               "My bad; improve me." %
                                (filename, package_name))
 
         get_version = (version_of_wheel
@@ -433,7 +439,7 @@ class DownloadedReq(object):
 
         """
         path, line = (re.match(r'-r (.*) \(line (\d+)\)$',
-                      self._req.comes_from).groups())
+                               self._req.comes_from).groups())
         return path, int(line)
 
     @memoize  # Avoid hitting the file[cache] over and over.
@@ -548,7 +554,6 @@ class DownloadedReq(object):
             size = 0
         pipe_to_file(response, join(self._temp_path, filename), size=size)
         return filename
-
 
     # Based on req_set.prepare_files() in pip bb2a8428d4aebc8d313d05d590f386fa3f0bbd0f
     @memoize  # Avoid re-downloading.
@@ -711,8 +716,8 @@ class MismatchedReq(DownloadedReq):
 
     def error(self):
         preamble = '    %s: expected%s' % (
-                self._project_name(),
-                ' one of' if len(self._expected_hashes()) > 1 else '')
+            self._project_name(),
+            ' one of' if len(self._expected_hashes()) > 1 else '')
         return '%s %s\n%s got %s' % (
             preamble,
             ('\n' + ' ' * (len(preamble) + 1)).join(self._expected_hashes()),
@@ -793,7 +798,7 @@ def downloaded_reqs_from_path(path, argv):
         # (nor do we need it at all) so we only import it in this except block
         from pip.download import PipSession
         return downloaded_reqs(parse_requirements(
-                path, options=EmptyOptions(), session=PipSession()))
+            path, options=EmptyOptions(), session=PipSession()))
 
 
 def peep_install(argv):

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 # Prevent spurious errors during `python setup.py test`, a la
 # http://www.eby-sarna.com/pipermail/peak/2010-May/003357.html:
 try:
-    import multiprocessing
+    import multiprocessing  # noqa
 except ImportError:
     pass
 
@@ -22,7 +22,7 @@ setup(
     entry_points={
         'console_scripts': ['peep = peep:main',
                             'peep-%s.%s = peep:main' % sys.version_info[:2]]
-        },
+    },
     url='https://github.com/erikrose/peep',
     include_package_data=True,
     # No dependencies are declared for peep, even though it requires pip.
@@ -44,7 +44,7 @@ setup(
         'Topic :: Software Development :: Build Tools',
         'Topic :: System :: Installation/Setup',
         'Topic :: System :: Systems Administration'
-        ],
+    ],
     keywords=['pip', 'secure', 'repeatable', 'deploy', 'deployment', 'hash',
               'install', 'installer']
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     pass
 
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 setup(

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -172,7 +172,7 @@ class InstallTestCase(TestCase):
         # Just in case the env was left dirty:
         try:
             run('pip uninstall -y useless')
-        except CalledProcessError as exc:  # happens when it's not installed
+        except CalledProcessError:  # happens when it's not installed
             pass
 
 
@@ -311,7 +311,7 @@ class FullStackTests(ServerTestCase):
 
         # Install the new version:
         self.install_from_string(
-           """# sha256: JIAjkT1OSM1PIxLbvKk46W4iOTqH9yHASHTwvGVEC4k
+            """# sha256: JIAjkT1OSM1PIxLbvKk46W4iOTqH9yHASHTwvGVEC4k
             {index_url}useless/789abcd.zip#egg=useless""".format(
                 index_url=self.index_url()))
         # Make sure the new version is really installed:
@@ -334,8 +334,8 @@ class HashParsingTests(ServerTestCase):
         """
         with requirements(text) as path:
             return downloaded_reqs_from_path(
-                    path,
-                    ['-r', path, '--index-url', self.index_url()])
+                path,
+                ['-r', path, '--index-url', self.index_url()])
 
     def test_inline_comments(self):
         """Make sure various permutations of inline comments are parsed

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -31,7 +31,7 @@ except ImportError:
 from nose import SkipTest
 from nose.tools import eq_, nottest
 
-from peep import EmptyOptions, SOMETHING_WENT_WRONG, downloaded_reqs_from_path, MissingReq, xrange, activate
+from peep import SOMETHING_WENT_WRONG, downloaded_reqs_from_path, MissingReq, xrange, activate
 
 
 @contextmanager


### PR DESCRIPTION
Treeherder is switching to using peep. The peep docs suggest checking peep.py into the repo, but we run flake8 against our repo on Travis (flake8 = pyflakes+pep8, with some extra magic to make pyflakes output more usable). To avoid having to add peep to the flake8 ignore list, let's fix some of the warnings, since I imagine this will affect others too.

See the individual commit messages for the list of flake8 warnings the changes fix.

Thanks! :-)