### PR TITLE
Travis: Allow jobs to run on the new container based infra

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
   - 3.4


### PR DESCRIPTION
Travis have a newer container based stack that runs on EC2, that is both faster (in terms of machine speed & time before a job begins to run) and allows the use of extra features (such as dependency caching):
http://docs.travis-ci.com/user/workers/container-based-infrastructure/

The main win from this for peep (seeing as the travis runs are already fast once they start) is to hopefully mean jobs don't wait 10+ minutes before there is a machine available to pick them up. (I get the impression their non-EC2 infra is only going to dwindle in pool size over time, as more people move to the EC2 stack).