### PR TITLE
Readme: Make it clearer that pip v6.0+ supports wheels

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -167,13 +167,13 @@ common.)
 Troubleshooting
 ===============
 
-Upgrading wheels
-----------------
+Upgrading wheels with old versions of pip
+-----------------------------------------
 
-If you're reusing a virtualenv, then you should avoid wheels until a version
-of pip that upgrades wheels properly is out. Otherwise, the old version of a
-package will not be entirely removed before the new one is installed. See
-https://github.com/pypa/pip/issues/1825 for more details.
+If you're reusing a virtualenv and using peep with pip <6.0, then you should
+avoid using wheels. Otherwise, the old version of a package will not be entirely
+removed before the new one is installed, due to:
+https://github.com/pypa/pip/issues/1825
 
 If you're using pip 1.4, don't pass the ``--use-wheel`` argument.
 

--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ Embedding
 =========
 
 Peep was designed for unsupervised continuous deployment scenarios. In such
-scenarios, manual ahead-of-time prepartion on the deployment machine is a
+scenarios, manual ahead-of-time preparation on the deployment machine is a
 liability: one more thing to go wrong. To relieve you of having to install (and
 upgrade) ``peep`` by hand on your server or build box, we've made ``peep``
 embeddable. You can copy the ``peep.py`` file directly into your project's


### PR DESCRIPTION
The previous wording implied that no fix was yet available, however the issue is resolved in 6.0+ by:
pypa/pip#1838
(Specifically see the release tags on https://github.com/pypa/pip/commit/5ace29fdebdc7ebc38d4859c93c733a15dfeefaa)

The wheels package format is superior, so we should not discourage users on modern versions of pip from using it.