### PR TITLE
Add flake8 to the Travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 sudo: false
 language: python
-# Stick to a known-good version of tox, just in case:
-install: pip install tox==1.9.2
-# Command to run tests. 3.1 is missing on Travis.
-script: tox --skip-missing-interpreters
+install:
+  # Stick to a known-good version of tox, just in case:
+  - pip install tox==1.9.2 flake8==2.4.0
+script:
+  # Run linter and then the test suite. 3.1 is missing on Travis.
+  - flake8 --show-source && tox --skip-missing-interpreters

--- a/peep.py
+++ b/peep.py
@@ -355,7 +355,6 @@ class DownloadedReq(object):
         self._argv = argv
         self._finder = finder
 
-
         # We use a separate temp dir for each requirement so requirements
         # (from different indices) that happen to have the same archive names
         # don't overwrite each other, leading to a security hole in which the

--- a/tox.ini
+++ b/tox.ini
@@ -1,3 +1,6 @@
+[flake8]
+max-line-length = 140
+
 [tox]
 # Test all pip versions >= 0.6.2 against Python 2.x.
 # Test pip 1.0 through 1.5.6 with Python 3.1 except pip 1.4-1.5.5 since they're


### PR DESCRIPTION
This will prevent flake8 regressions (eg the one that was introduced between peep 2.3 and peep 2.4). If flake8 finds issues, the Travis run will fail early, and the tox tests will not be run. 

flake8, like pep8 has a default max line length of 80 characters, which is annoying, so this has been increased to 140 characters. Ideally we'd just disable the line length check entirely, but by specifying an 'ignore' option in tox.ini, it overrides the default ignore list, so we would have to keep it up to date, which would be a pain. We can always raise the threshold to 999 characters, were we to get undesired line length warnings in the future.