### PR TITLE
Readme: Fix the link target for the Travis build status image

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,5 @@
-.. image:: https://api.travis-ci.org/erikrose/peep.svg
+.. image:: https://travis-ci.org/erikrose/peep.svg?branch=master
+    :target: https://travis-ci.org/erikrose/peep
 
 ====
 Peep


### PR DESCRIPTION
The current image links to the image itself, not the Travis page.
In addition, the new image shows just the status of master, not the latest build to have run.

Updated using the instructions at:
http://docs.travis-ci.com/user/status-images/