### PR TITLE
don't allow duplicate names

### DIFF
--- a/peep.py
+++ b/peep.py
@@ -831,8 +831,15 @@ def peep_install(argv):
         reqs = list(chain.from_iterable(
             downloaded_reqs_from_path(path, argv)
             for path in req_paths))
-        buckets = bucket(reqs, lambda r: r.__class__)
 
+        # Check there are no duplicated names.
+        names = tuple(r._req.name for r in reqs)
+        duplicates = set([i for i in names if names.count(i) > 1])
+        if duplicates:
+            out('Duplicated names in file: {0}'.format(', '.join(duplicates)))
+            return SOMETHING_WENT_WRONG
+
+        buckets = bucket(reqs, lambda r: r.__class__)
         # Skip a line after pip's "Cleaning up..." so the important stuff
         # stands out:
         if any(buckets[b] for b in ERROR_CLASSES):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -314,6 +314,20 @@ class FullStackTests(ServerTestCase):
             else:
                 self.fail("Peep exited successfully but shouldn't have.")
 
+    def test_duplicated(self):
+        """If a module is duplicated, peep should explode."""
+        with running_setup_py(False):
+            try:
+                self.install_from_string(
+                    """# sha256: f_y0x5sQfR1nj8HXuHStXojp_ihntAG-clNT2MNxF10
+                    useless==1.0
+                    # sha256: f_y0x5sQfR1nj8HXuHStXojp_ihntAG-clNT2MNxF10
+                    useless==1.0""")
+            except CalledProcessError as exc:
+                eq_(exc.returncode, SOMETHING_WENT_WRONG)
+            else:
+                self.fail("Peep exited successfully but shouldn't have.")
+
     def test_missing(self):
         """If a hash is missing, peep should explode."""
         with running_setup_py(False):


### PR DESCRIPTION
it sucks when you've got duplicate modules in a requirements file, this stops peep from trying to do anything with them