### PR TITLE
Possible fix to #103; whl capitalization

### DIFF
--- a/peep.py
+++ b/peep.py
@@ -400,7 +400,7 @@ class DownloadedReq(object):
             whl_package_name, version, _rest = filename.split('-', 2)
             # Do the alteration to package_name from PEP 427:
             our_package_name = re.sub(r'[^\w\d.]+', '_', package_name, re.UNICODE)
-            if whl_package_name != our_package_name:
+            if whl_package_name != our_package_name and whl_package_name.lower() != our_package_name.lower():
                 give_up(filename, whl_package_name)
             return version
 


### PR DESCRIPTION
Compare .lower()s of whl_package_name and our_name when getting version in case capitalization is inconsistent across the two