### PR TITLE
Print source requirement file in peep_port

### DIFF
--- a/peep.py
+++ b/peep.py
@@ -904,14 +904,21 @@ def peep_port(paths):
         print('Please specify one or more requirements files so I have '
               'something to port.\n')
         return COMMAND_LINE_ERROR
+
+    comes_from = None
     for req in chain.from_iterable(
             _parse_requirements(path, package_finder(argv)) for path in paths):
+        req_path, req_line = path_and_line(req)
         hashes = [hexlify(urlsafe_b64decode((hash + '=').encode('ascii'))).decode('ascii')
-                  for hash in hashes_above(*path_and_line(req))]
+                  for hash in hashes_above(req_path, req_line)]
+        if req_path != comes_from:
+            print()
+            print('# from %s' % req_path)
+            print()
+            comes_from = req_path
+
         if not hashes:
             print(req.req)
-        elif len(hashes) == 1:
-            print('%s --hash=sha256:%s' % (req.req, hashes[0]))
         else:
             print('%s' % req.req, end='')
             for hash in hashes:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -405,13 +405,16 @@ class FullStackTests(ServerTestCase):
                          peep=peep_path(),
                          reqs=reqs_path).decode('ascii')
         expected = (
+            '\n# from {reqs_path}\n\n'
             'certifi==2015.04.28 \\\n'
             '    --hash=sha256:268fa00c27de756d71663dd61f73a4a8d8727569bb1b474b2ce6020553826872 \\\n'
             '    --hash=sha256:99785e6cf715cdcde59dee05a676e99f04835a71e7ced201ca317401c322ba96\n'
-            'click==4.0 --hash=sha256:9ab1d313f99b209f8f71a629f36833030c8d7c72282cf7756834baf567dca662\n'
+            'click==4.0 \\\n'
+            '    --hash=sha256:9ab1d313f99b209f8f71a629f36833030c8d7c72282cf7756834baf567dca662\n'
             'configobj==5.0.6\n'
-            '{schema} --hash=sha256:98414ccbb99090239729968fe4225a3173e3f0ec1bb5e5bd766abd76bc19a8d9\n'.format(
-                schema=schema_package_name))
+            '{schema} \\\n'
+            '    --hash=sha256:98414ccbb99090239729968fe4225a3173e3f0ec1bb5e5bd766abd76bc19a8d9\n'
+            ''.format(schema=schema_package_name, reqs_path=reqs_path))
         eq_(result, expected)
 
 


### PR DESCRIPTION
Will print as a comment the source requirement file path whenver it changes. This should help in splitting the files back out if they were originall split.

Also removes the different format for a single hash. I find this makes for a much more pleasing file, but could be convinced to leave it alone.