### PR TITLE
The 'port' command returns a package name instead of the original link.

### DIFF
--- a/peep.py
+++ b/peep.py
@@ -920,7 +920,7 @@ def peep_port(paths):
         if not hashes:
             print(req.req)
         else:
-            print('%s' % req.req, end='')
+            print('%s' % (req.link if getattr(req, 'link', None) else req.req), end='')
             for hash in hashes:
                 print(' \\')
                 print('    --hash=sha256:%s' % hash, end='')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -376,11 +376,16 @@ class FullStackTests(ServerTestCase):
         # We can't get the package name from URL-based requirements before pip
         # 1.0. Tolerate it so we can at least test everything else:
         try:
-            activate('pip>=1.0.1')
+            activate('pip>=6.1.0')
         except RuntimeError:
-            schema_package_name = 'None'
+            try:
+                activate('pip>=1.0.1')
+            except RuntimeError:
+                schema_package_name = 'None'
+            else:
+                schema_package_name = 'schema'
         else:
-            schema_package_name = 'schema'
+            schema_package_name = 'https://github.com/erikrose/schema/archive/99dc4130f0f05fd3c2d4bc6663a2419851f3c90f.zip#egg=schema'
 
         reqs = """
             # sha256: Jo-gDCfedW1xZj3WH3OkqNhydWm7G0dLLOYCBVOCaHI


### PR DESCRIPTION
Hi @erikrose,
During our migration from peep to pip 8 i've discovered that `peep port` can't port requirements that rely on the urls to the remote resources.
Could you review my patch?
Unfortunately i couldn't find any tests for `peep port` but I can add them if you wish so.

Thanks for your hard work on peep and pip8!
