### PR TITLE
Handle pip InstallationError exceptions more gracefully

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.tox
+/*.egg-info
 /pip-log.txt
+*.pyc

--- a/README.rst
+++ b/README.rst
@@ -264,6 +264,11 @@ If you're using pip 1.5, pass the ``--no-use-wheel`` argument.
 Version History
 ===============
 
+Unreleased:
+  * The "peep had a problem" traceback is no longer output for several cases
+    of pip installation errors that were not peep's fault. (For instance the
+    specified package version or requirements file not existing.)
+
 3.1
   * Print the name each new requirements file we encounter during ``peep
     port``. This helps untangle the mess if your files use includes. (pmac)

--- a/peep.py
+++ b/peep.py
@@ -122,6 +122,7 @@ ITS_FINE_ITS_FINE = 0
 SOMETHING_WENT_WRONG = 1
 # "Traditional" for command-line errors according to optparse docs:
 COMMAND_LINE_ERROR = 2
+UNHANDLED_EXCEPTION = 3
 
 ARCHIVE_EXTENSIONS = ('.tar.bz2', '.tar.gz', '.tgz', '.tar', '.zip')
 
@@ -965,4 +966,4 @@ if __name__ == '__main__':
         exit(main())
     except Exception:
         exception_handler(*sys.exc_info())
-        exit(SOMETHING_WENT_WRONG)
+        exit(UNHANDLED_EXCEPTION)

--- a/peep.py
+++ b/peep.py
@@ -86,6 +86,7 @@ except ImportError:
         from pip.util import url_to_path  # 0.7.0
     except ImportError:
         from pip.util import url_to_filename as url_to_path  # 0.6.2
+from pip.exceptions import InstallationError
 from pip.index import PackageFinder, Link
 try:
     from pip.log import logger
@@ -885,7 +886,7 @@ def peep_install(argv):
             first_every_last(buckets[SatisfiedReq], *printers)
 
         return ITS_FINE_ITS_FINE
-    except (UnsupportedRequirementError, DownloadError) as exc:
+    except (UnsupportedRequirementError, InstallationError, DownloadError) as exc:
         out(str(exc))
         return SOMETHING_WENT_WRONG
     finally:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -339,6 +339,33 @@ class FullStackTests(ServerTestCase):
             else:
                 self.fail("Peep exited successfully but shouldn't have.")
 
+    def test_distribution_not_found(self):
+        """Check that pip's DistributionNotFound exception (when a non-existent
+        version is specified) is handled gracefully."""
+        with running_setup_py(False):
+            try:
+                self.install_from_string("""useless==9.9.9""")
+            except CalledProcessError as exc:
+                eq_(exc.returncode, SOMETHING_WENT_WRONG)
+            else:
+                self.fail("Peep exited successfully but shouldn't have.")
+
+    def test_missing_requirements_file(self):
+        """Check that pip's InstallationError exception (when the specified
+        requirements file doesn't exist) is handled gracefully."""
+        try:
+            activate('pip>=0.8.3')
+        except RuntimeError:
+            raise SkipTest("This version of pip is so old that it doesn't even "
+                           "handle the IOError opening the file itself properly.")
+        with running_setup_py(False):
+            try:
+                self.install_from_path('nonexistent.txt')
+            except CalledProcessError as exc:
+                eq_(exc.returncode, SOMETHING_WENT_WRONG)
+            else:
+                self.fail("Peep exited successfully but shouldn't have.")
+
     def test_upgrade(self):
         """Make sure peep installing a GitHub-sourced tarball installs it,
         even if its version hasn't changed.


### PR DESCRIPTION
`InstallationError` covers various "not peep's fault" errors, including no valid distribution being found for the requested package version, the requirements file being missing, or the contents not being valid:
https://github.com/pypa/pip/blob/8.0.2/pip/exceptions.py
https://github.com/pypa/pip/search?q="raise+InstallationError"&type=Code

Previously these would have resulted in the "peep had a problem" output, which requests that users file an issue - when these cases are not peep's fault. Now the original pip error is output as-is, without the peep traceback.

The tests rely on the exit code for unhandled exceptions being different from that for handled exceptions, which has also been fixed in this PR.

Fixes #117.