### PR TITLE
Fix compatibility with pip 8.1.2.

### DIFF
--- a/peep.py
+++ b/peep.py
@@ -54,7 +54,7 @@ except ImportError:
     from urllib.parse import urlparse  # 3.4
 # TODO: Probably use six to make urllib stuff work across 2/3.
 
-from pkg_resources import require, VersionConflict, DistributionNotFound
+from pkg_resources import require, VersionConflict, DistributionNotFound, safe_name
 
 # We don't admit our dependency on pip in setup.py, lest a naive user simply
 # say `pip install peep.tar.gz` and thus pull down an untrusted copy of pip
@@ -665,6 +665,9 @@ class DownloadedReq(object):
         name = getattr(self._req.req, 'project_name', '')
         if name:
             return name
+        name = getattr(self._req.req, 'name', '')
+        if name:
+            return safe_name(name)
         raise ValueError('Requirement has no project_name.')
 
     def _name(self):


### PR DESCRIPTION
When using pip 8.1.2, peep cannot get the project_name for packages listed in requirements.txt.  This stops it from being able to install anything.  STR:

```
$ virtualenv venv
New python executable in .../venv/bin/python
Installing setuptools, pip, wheel...done.
$ . ./venv/bin/activate
$ pip --version
pip 8.1.2 from .../venv/lib/python2.7/site-packages (python 2.7)
$ cat requirements.txt
# sha256: HDW0rCBs7y0kgWyJ-Jzyid09OM98RJuz-re_bUPwGx8
ordereddict==1.1

$ ./peep.py install -r requirements.txt

The following requirements could not be processed:
* Unable to determine package name from URL None; add #egg=
-------------------------------
Not proceeding to installation.

$
```

In 8.1.2, the type of `req` has changed and it no longer has a `project_name` attribute.  Instead we can compute this from the `name` attribute. 
